### PR TITLE
Prod

### DIFF
--- a/py/qsonic/__init__.py
+++ b/py/qsonic/__init__.py
@@ -1,3 +1,3 @@
 __author__ = 'Naim Goksel Karacayli'
 __email__ = 'ngokselk@gmail.com'
-__version__ = '0.1.1'
+__version__ = '0.1.2'

--- a/py/qsonic/__init__.py
+++ b/py/qsonic/__init__.py
@@ -1,3 +1,3 @@
 __author__ = 'Naim Goksel Karacayli'
 __email__ = 'ngokselk@gmail.com'
-__version__ = '0.1.2'
+__version__ = '0.2.0'

--- a/py/qsonic/catalog.py
+++ b/py/qsonic/catalog.py
@@ -70,10 +70,10 @@ def read_quasar_catalog(
     return catalog
 
 
-def mpi_read_local_qso_catalog(
-        filename, comm, mpi_rank, mpi_size, is_mock,
+def mpi_read_quasar_catalog(
+        filename, comm, mpi_rank, is_mock,
         keep_surveys=None, zmin=2.1, zmax=6.0):
-    """ Returns quasar catalog object for mpi_rank.
+    """ Returns the same quasar catalog object on all MPI ranks.
 
     It is sorted in the following order: HPXPIXEL, SURVEY (if applicable),
     TARGETID. BAL info included if available. It is required for BAL masking.
@@ -86,8 +86,6 @@ def mpi_read_local_qso_catalog(
         MPI comm object for bcast
     mpi_rank: int
         Rank of the MPI process
-    mpi_size: int
-        Size of MPI processes
     is_mock: bool
         If the catalog is for mocks.
     keep_surveys: None or list(str), default: None
@@ -99,8 +97,8 @@ def mpi_read_local_qso_catalog(
 
     Returns
     ----------
-    local_queue: list(:external+numpy:py:class:`ndarray <numpy.ndarray>`)
-        List of sorted catalogs.
+    catalog: :external+numpy:py:class:`ndarray <numpy.ndarray>`
+        Sorted catalog on all MPI ranks.
     """
     catalog = None
 
@@ -116,10 +114,10 @@ def mpi_read_local_qso_catalog(
     if catalog is None:
         raise Exception("Error while reading catalog.")
 
-    return _mpi_get_local_queue(catalog, mpi_rank, mpi_size)
+    return catalog
 
 
-def _mpi_get_local_queue(catalog, mpi_rank, mpi_size):
+def mpi_get_local_queue(catalog, mpi_rank, mpi_size):
     """ Take a 'HPXPIXEL' sorted `catalog` and assign a list of catalogs to
     mpi_rank
 

--- a/py/qsonic/io.py
+++ b/py/qsonic/io.py
@@ -185,7 +185,7 @@ def save_deltas(
 
     for healpix, hp_specs in zip(unique_pix, split_spectra):
         results = fitsio.FITS(
-            f"{outdir}/deltas-{healpix}.fits", 'rw', clobber=True)
+            f"{outdir}/delta-{healpix}.fits", 'rw', clobber=True)
 
         for spec in qsonic.spectrum.valid_spectra(hp_specs):
             spec.write(results, varlss_interp)

--- a/py/qsonic/io.py
+++ b/py/qsonic/io.py
@@ -27,46 +27,39 @@ def add_io_parser(parser=None):
         parser = argparse.ArgumentParser(
             formatter_class=argparse.ArgumentDefaultsHelpFormatter)
 
-    iogroup = parser.add_argument_group(
-        'Input/output parameters and selections')
-    iogroup.add_argument(
+    ingroup = parser.add_argument_group('Input options')
+    ingroup.add_argument(
         "--input-dir", '-i', required=True,
         help="Input directory to healpix")
-    iogroup.add_argument(
+    ingroup.add_argument(
         "--catalog", required=True,
         help="Catalog filename")
-    iogroup.add_argument(
-        "--outdir", '-o',
-        help="Output directory to save deltas.")
-    iogroup.add_argument(
+    ingroup.add_argument(
         "--mock-analysis", action="store_true",
         help="Input folder is mock. Uses nside=16")
-    iogroup.add_argument(
+    ingroup.add_argument(
         "--keep-surveys", nargs='+', default=['sv3', 'main'],
         help="Surveys to keep.")
-    iogroup.add_argument(
-        "--coadd-arms", action="store_true",
-        help="Coadds arms when saving.")
-
-    iogroup.add_argument(
+    ingroup.add_argument(
         "--skip-resomat", action="store_true",
         help="Skip reading resolution matrix for 3D.")
-    iogroup.add_argument(
+    ingroup.add_argument(
         "--arms", default=['B', 'R'], choices=['B', 'R', 'Z'], nargs='+',
         help="Arms to read.")
-    iogroup.add_argument(
-        "--min-rsnr", type=float, default=0.,
-        help="Minium SNR <F/sigma> above Lya.")
-    iogroup.add_argument(
-        "--skip", type=_float_range(0, 1), default=0.,
-        help="Skip short spectra lower than given ratio.")
-    iogroup.add_argument(
+
+    outgroup = parser.add_argument_group('Output options')
+    outgroup.add_argument(
+        "--outdir", '-o',
+        help="Output directory to save deltas.")
+    outgroup.add_argument(
+        "--coadd-arms", action="store_true",
+        help="Coadds arms when saving.")
+    outgroup.add_argument(
+        "--save-smooth-weights", action="store_true",
+        help="Save smoothed weights instead.")
+    outgroup.add_argument(
         "--save-by-hpx", action="store_true",
         help="Save by healpix. If not, saves by MPI rank.")
-    iogroup.add_argument(
-        "--keep-nonforest-pixels", action="store_true",
-        help="Keeps non forest wavelengths. Memory intensive!")
-
     return parser
 
 
@@ -141,7 +134,9 @@ def read_spectra_onehealpix(
 
 
 def save_deltas(
-        spectra_list, outdir, varlss_interp, save_by_hpx=False, mpi_rank=None):
+        spectra_list, outdir, varlss_interp,
+        save_by_hpx=False, mpi_rank=None, use_ivar_sm=False
+):
     """ Saves given list of spectra as deltas. NO coaddition of arms.
     Each arm is saved separately. Only valid spectra are saved.
 
@@ -153,10 +148,12 @@ def save_deltas(
         Output directory. Does not save if empty of None
     varlss_interp: Interpolator
         Interpolator for LSS variance
-    save_by_hpx: bool
+    save_by_hpx: bool, default: False
         Saves by healpix if True. Has priority over mpi_rank
-    mpi_rank: int
+    mpi_rank: int, default: None
         Rank of the MPI process. Save by `mpi_rank` if passed.
+    use_ivar_sm: bool, default: False
+        Use :attr:`Spectrum.forestivar_sm` in weights instead.
 
     Raises
     ---------
@@ -188,7 +185,7 @@ def save_deltas(
             f"{outdir}/delta-{healpix}.fits", 'rw', clobber=True)
 
         for spec in qsonic.spectrum.valid_spectra(hp_specs):
-            spec.write(results, varlss_interp)
+            spec.write(results, varlss_interp, use_ivar_sm)
 
         results.close()
 

--- a/py/qsonic/scripts/qsonic_fit.py
+++ b/py/qsonic/scripts/qsonic_fit.py
@@ -194,9 +194,12 @@ def mpi_run_all(comm, mpi_rank, mpi_size):
         os_makedirs(args.outdir, exist_ok=True)
 
     # read catalog
-    local_queue = qsonic.catalog.mpi_read_local_qso_catalog(
-        args.catalog, comm, mpi_rank, mpi_size, is_mock=args.mock_analysis,
+    full_catalog = qsonic.catalog.mpi_read_quasar_catalog(
+        args.catalog, comm, mpi_rank, is_mock=args.mock_analysis,
         keep_surveys=args.keep_surveys)
+
+    local_queue = qsonic.catalog.mpi_get_local_queue(
+        full_catalog, mpi_rank, mpi_size)
 
     # Blinding
     qsonic.spectrum.Spectrum.set_blinding(local_queue, args)

--- a/py/qsonic/scripts/qsonic_fit.py
+++ b/py/qsonic/scripts/qsonic_fit.py
@@ -32,6 +32,18 @@ def get_parser(add_help=True):
         formatter_class=argparse.ArgumentDefaultsHelpFormatter)
 
     parser = qsonic.io.add_io_parser(parser)
+
+    analysis_group = parser.add_argument_group('Analysis options')
+    analysis_group.add_argument(
+        "--min-rsnr", type=float, default=0.,
+        help="Minium SNR <F/sigma> above Lya.")
+    analysis_group.add_argument(
+        "--skip", type=qsonic.io._float_range(0, 1), default=0.,
+        help="Skip short spectra lower than given ratio.")
+    analysis_group.add_argument(
+        "--keep-nonforest-pixels", action="store_true",
+        help="Keeps non forest wavelengths. Memory intensive!")
+
     parser = qsonic.spectrum.add_wave_region_parser(parser)
     parser = qsonic.masks.add_mask_parser(parser)
     parser = add_picca_continuum_parser(parser)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
-numpy
-numba
-scipy
-healpy
-fitsio
+numpy>=1.23
+numba>=0.56
+scipy>=1.9
+healpy>=1.16
+fitsio>=1.1
 mpi4py

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.1.2
+current_version = 0.2.0
 commit = True
 tag = True
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.1.1
+current_version = 0.1.2
 commit = True
 tag = True
 
@@ -35,14 +35,14 @@ console_scripts =
 	qsonic-fit = qsonic.scripts.qsonic_fit:main
 
 [options.extras_require]
-dev =
+dev = 
 	pytest
 	flake8
 	bump2version
-doc =
+doc = 
 	sphinx
 	sphinx-argparse
 	sphinx-rtd-theme
-pub =
+pub = 
 	build
 	twine

--- a/tests/test_catalog.py
+++ b/tests/test_catalog.py
@@ -118,8 +118,8 @@ class TestCatalog(object):
             dtype=cat_dtype)
 
         mpi_size = 2
-        q0 = qsonic.catalog._mpi_get_local_queue(input_catalog, 0, mpi_size)
-        q1 = qsonic.catalog._mpi_get_local_queue(input_catalog, 1, mpi_size)
+        q0 = qsonic.catalog.mpi_get_local_queue(input_catalog, 0, mpi_size)
+        q1 = qsonic.catalog.mpi_get_local_queue(input_catalog, 1, mpi_size)
         assert (len(q0) == 2)
         assert (len(q1) == 2)
         npt.assert_equal(q0[0]['TARGETID'], [666, 667, 668])


### PR DESCRIPTION
Merge with v0.2.0. This version:
- Fixes delta filename output to match picca conventions.
- Adds minimums to requirements
- Removes qsonic.io.mpi_read_local_qso_catalog(). This can be done in two functions calls anyway.
- Adds Option to save smooth weights in delta files.
- Regroup argument parser options.