### PR TITLE
Fix skip-resomat option in mocks

### DIFF
--- a/py/qsonic/io.py
+++ b/py/qsonic/io.py
@@ -600,20 +600,19 @@ def read_onehealpix_file_mock(
     data, idx_cat = _read_onehealpix_file(
         catalog_hpx['TARGETID'], fspec, arms_to_keep, skip_resomat)
 
+    if idx_cat.size != catalog_hpx.size:
+        catalog_hpx = catalog_hpx[idx_cat]
+
     fspec = f"{input_dir}/{pixnum//100}/{pixnum}/truth-{nside}-{pixnum}.fits"
     if read_true_continuum:
-        data['cont'] = _read_true_continuum(
-            catalog_hpx['TARGETID'][idx_cat], fspec)
+        data['cont'] = _read_true_continuum(catalog_hpx['TARGETID'], fspec)
 
     if skip_resomat:
-        return data, idx_cat
+        return qsonic.spectrum.generate_spectra_list_from_data(catalog_hpx, data)
 
     with fitsio.FITS(fspec) as fitsfile:
         for arm in arms_to_keep:
             data['reso'][arm] = np.array(fitsfile[f'{arm}_RESOLUTION'].read())
-
-    if idx_cat.size != catalog_hpx.size:
-        catalog_hpx = catalog_hpx[idx_cat]
 
     return qsonic.spectrum.generate_spectra_list_from_data(catalog_hpx, data)
 

--- a/py/qsonic/scripts/qsonic_calib.py
+++ b/py/qsonic/scripts/qsonic_calib.py
@@ -276,6 +276,6 @@ def main():
         logging.exception(e)
         exit(1)
     except Exception as e:
-        logging.critical(f"Unexpected error on Rank{mpi_rank}. Abort.")
-        logging.exception(e)
+        logging.critical(
+            f"Unexpected error on Rank{mpi_rank}: {e}. Abort.", exc_info=True)
         comm.Abort()

--- a/py/qsonic/scripts/qsonic_fit.py
+++ b/py/qsonic/scripts/qsonic_fit.py
@@ -367,8 +367,8 @@ def main():
         logging.exception(e)
         exit(1)
     except Exception as e:
-        logging.critical(f"Unexpected error on Rank{mpi_rank}. Abort.")
-        logging.exception(e)
+        logging.critical(
+            f"Unexpected error on Rank{mpi_rank}: {e}. Abort.", exc_info=True)
         comm.Abort()
 
     etime = (time.time() - start_time) / 60  # min


### PR DESCRIPTION
When the resolution matrix was skipped, the IO function returned the dictionary before this fix. Also logging exceptions is fixed for rank != 0 tasks