### PR TITLE
Outlier masking in set_forest_region

### DIFF
--- a/py/qsonic/masks.py
+++ b/py/qsonic/masks.py
@@ -74,7 +74,8 @@ class SkyMask():
         self.mask_obs_frame = mask[mask['frame'] == 'OBS']
 
     def apply(self, spec):
-        """ Apply the mask by setting **only** ``spec.forestivar`` to zero.
+        """ Apply the mask by setting **only** ``spec.forestivar`` and
+        ``spec.forestflux`` to zero.
 
         Arguments
         ----------
@@ -100,6 +101,7 @@ class SkyMask():
             for idx1, idx2 in mask_idx_ranges:
                 w[idx1:idx2] = 1
 
+            spec.forestflux[arm][w] = 0
             spec.forestivar[arm][w] = 0
 
 
@@ -152,7 +154,8 @@ class BALMask():
 
     @staticmethod
     def apply(spec):
-        """ Apply the mask by setting **only** ``spec.forestivar`` to zero.
+        """ Apply the mask by setting **only** ``spec.forestivar`` and
+        ``spec.forestflux`` to zero.
 
         Arguments
         ----------
@@ -192,6 +195,7 @@ class BALMask():
             for idx1, idx2 in mask_idx_ranges:
                 w[idx1:idx2] = 1
 
+            spec.forestflux[arm][w] = 0
             spec.forestivar[arm][w] = 0
 
 
@@ -428,7 +432,8 @@ class DLAMask():
         self.split_catalog = np.split(catalog, s[1:])
 
     def apply(self, spec):
-        """ Apply the mask by setting **only** ``spec.forestivar`` to zero.
+        """ Apply the mask by setting ``spec.forestivar`` and
+        ``spec.forestflux`` to zero.
 
         Arguments
         ----------

--- a/py/qsonic/mathtools.py
+++ b/py/qsonic/mathtools.py
@@ -180,6 +180,34 @@ def fft_gaussian_smooth(x, sigma_pix=20, mode='edge'):
     return y
 
 
+def get_median_outlier_mask(flux, ivar, esigma=3.5):
+    """Calculates median of flux and sigma = 1.4826 * MAD. Returns a boolean
+    array to mask pixels if ``abs(f[i] - median) > esigma * max(n[i], sigma)``.
+
+    Arguments
+    ---------
+    flux: :external+numpy:py:class:`ndarray <numpy.ndarray>`
+        Flux array.
+    ivar: :external+numpy:py:class:`ndarray <numpy.ndarray>`
+        Inverse variance array.
+    esigma: float, default: 3.5
+        Sigma to identify outliers via MAD.
+
+    Returns
+    ---------
+    mask: :external+numpy:py:class:`ndarray <numpy.ndarray>`
+        Bool array. Mask if true.
+    """
+    w = ivar != 0
+    if not any(w):
+        return np.ones(flux.size, dtype=bool)
+
+    abs_diff = np.abs(flux - np.median(flux[w]))
+    isig_mad = min(1.0, 1.0 / (1.4826 * np.median(abs_diff[w])))
+    isig_cut = np.fmin(np.sqrt(ivar), isig_mad) / esigma
+    return abs_diff * isig_cut > 1.0
+
+
 def get_smooth_ivar(ivar, sigma_pix=20, esigma=3.5):
     """ Smoothing ``ivar`` values to reduce signal-noise coupling.
 

--- a/py/qsonic/spectrum.py
+++ b/py/qsonic/spectrum.py
@@ -2,7 +2,8 @@ import argparse
 
 import numpy as np
 
-from qsonic.mathtools import _zero_function, _one_function, get_smooth_ivar
+from qsonic.mathtools import (
+    _zero_function, _one_function, get_smooth_ivar, get_median_outlier_mask)
 
 
 def add_wave_region_parser(parser=None):
@@ -282,8 +283,11 @@ class Spectrum():
         self.cont_params['x'][0] /= cont_params_weight
 
     def set_forest_region(self, w1, w2, lya1, lya2):
-        """ Sets slices for the forest region. Also calculates the mean SNR in
-        the forest and an initial guess for the continuum amplitude.
+        """ Sets slices for the forest region. Masks outliers in each arm
+        separately based on median statistics
+        (see :func:`qsonic.mathtools.get_median_outlier_mask`). Also calculates
+        the mean SNR in the forest and an initial guess for the continuum
+        amplitude.
 
         Arguments
         ---------
@@ -304,7 +308,6 @@ class Spectrum():
 
             self._f1[arm], self._f2[arm] = ii1, ii2
 
-            # Does this create a view or copy array?
             # See https://numpy.org/doc/stable/user/basics.copies.html
             # Slicing creates views, not copies. Bases of views are not removed
             # from memory!
@@ -313,6 +316,11 @@ class Spectrum():
             self._forestivar[arm] = self.ivar[arm][ii1:ii2].copy()
             if self.reso:
                 self._forestreso[arm] = self.reso[arm][:, ii1:ii2].copy()
+
+            w = get_median_outlier_mask(
+                self._forestflux[arm], self._forestivar[arm])
+            self._forestflux[arm][w] = 0
+            self._forestivar[arm][w] = 0
 
         self._forestivar_sm = self._forestivar
         self._forestweight = self._forestivar

--- a/py/qsonic/spectrum.py
+++ b/py/qsonic/spectrum.py
@@ -284,7 +284,7 @@ class Spectrum():
 
     def set_forest_region(self, w1, w2, lya1, lya2):
         """ Sets slices for the forest region. Masks outliers in each arm
-        separately based on median statistics
+        separately based on moving median statistics
         (see :func:`qsonic.mathtools.get_median_outlier_mask`). Also calculates
         the mean SNR in the forest and an initial guess for the continuum
         amplitude.

--- a/tests/test_mathtools.py
+++ b/tests/test_mathtools.py
@@ -46,6 +46,28 @@ class TestMathtools(object):
         xarr_sm = qsonic.mathtools.fft_gaussian_smooth(xarr)
         npt.assert_allclose(xarr, xarr_sm)
 
+    def test_get_median_outlier_mask(self):
+        rng = np.random.default_rng(10)
+        size = 100
+        sigmas = 1 + rng.poisson(5, size=size).astype(float)
+        ivar = sigmas**-2
+        flux = rng.normal(0, sigmas)
+
+        w = qsonic.mathtools.get_median_outlier_mask(flux, ivar)
+        assert not any(w)
+
+        flux[20] = 1e3
+        w = qsonic.mathtools.get_median_outlier_mask(flux, ivar)
+        assert w[20]
+        assert not any(w[:20]) and not any(w[21:])
+
+        ivar[20:40] = 0
+
+        w = qsonic.mathtools.get_median_outlier_mask(flux, ivar)
+        assert all(w[20:40])
+        assert not any(w[:20])
+        assert not any(w[40:])
+
     def test_get_smooth_ivar(self):
         ivar = np.ones(2**10)
         idces = np.array([16, 17, 18, 234, 235, 512, 667, 898, 910, 956])

--- a/tests/test_spectrum.py
+++ b/tests/test_spectrum.py
@@ -58,7 +58,6 @@ class TestSpectrum(object):
         assert (not spec.forestreso)
 
         spec.flux['B'][10:15] = 1e2
-        spec.ivar['B'][10:15] = 0
         spec.set_forest_region(3600., 6000., 1050., 1180.)
         npt.assert_equal(spec.forestflux['B'][10:15], 0)
 

--- a/tests/test_spectrum.py
+++ b/tests/test_spectrum.py
@@ -57,6 +57,11 @@ class TestSpectrum(object):
         assert ('R' not in spec.forestflux.keys())
         assert (not spec.forestreso)
 
+        spec.flux['B'][10:15] = 1e2
+        spec.ivar['B'][10:15] = 0
+        spec.set_forest_region(3600., 6000., 1050., 1180.)
+        npt.assert_equal(spec.forestflux['B'][10:15], 0)
+
     def test_drop_short_arms(self, setup_data):
         cat_by_survey, _, data = setup_data(1)
         spectra_list = qsonic.spectrum.generate_spectra_list_from_data(


### PR DESCRIPTION
This PR applies a simple outlier masking with median statistics to the forest region in order to improve resilience against DESI pipeline mishaps.