### PR TITLE
Input continuum model

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -22,6 +22,7 @@ QSOnic
 
 The key differences
 -------------------
+- You can use any desired input continuum from another continuum prediction method as input continuum model.
 - Coadding of spectrograph arms can be performed after continuum fitting or disabled entirely.
 - Continuum is multiplied by a fiducial mean flux when provided.
 - You can pass fiducial var_lss (column **VAR_LSS**) and mean flux (column **MEANFLUX**) for observed wavelength **LAMBDA** in **STATS** extention of a FITS file. Wavelength should be linearly and equally spaced. This is the same format as rawio output from picca, except **VAR** column in picca is the variance on flux not deltas. We break away from that convention by explicitly requiring variance on deltas in a new column.

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -49,6 +49,7 @@ autodoc_default_options = {
     'exclude-members': '__init__',
     'private-members': True
 }
+add_module_names = False
 
 exclude_patterns = []
 

--- a/docs/source/generated/calibration.rst
+++ b/docs/source/generated/calibration.rst
@@ -1,4 +1,4 @@
-qsonic.calibration
+calibration
 =========================
 
 .. automodule:: qsonic.calibration

--- a/docs/source/generated/catalog.rst
+++ b/docs/source/generated/catalog.rst
@@ -1,4 +1,4 @@
-qsonic.catalog
+catalog
 =======================
 
 .. automodule:: qsonic.catalog

--- a/docs/source/generated/continuum_models.rst
+++ b/docs/source/generated/continuum_models.rst
@@ -1,0 +1,21 @@
+qsonic.continuum_models
+=======================
+
+qsonic.continuum_models.base_continuum_model
+----------------------------------------------
+
+
+.. automodule:: qsonic.continuum_models.base_continuum_model
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+
+qsonic.continuum_models.picca_continuum_model
+----------------------------------------------
+
+
+.. automodule:: qsonic.continuum_models.picca_continuum_model
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/generated/continuum_models.rst
+++ b/docs/source/generated/continuum_models.rst
@@ -19,3 +19,13 @@ qsonic.continuum_models.picca_continuum_model
    :members:
    :undoc-members:
    :show-inheritance:
+
+
+qsonic.continuum_models.true_continuum_model
+----------------------------------------------
+
+
+.. automodule:: qsonic.continuum_models.true_continuum_model
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/generated/continuum_models.rst
+++ b/docs/source/generated/continuum_models.rst
@@ -1,10 +1,9 @@
-qsonic.continuum_models
+continuum_models
 =======================
 
 .. automodule:: qsonic.continuum_models.base_continuum_model
    :members:
    :undoc-members:
-   :show-inheritance:
 
 
 .. automodule:: qsonic.continuum_models.picca_continuum_model

--- a/docs/source/generated/continuum_models.rst
+++ b/docs/source/generated/continuum_models.rst
@@ -1,25 +1,7 @@
 continuum_models
 =======================
 
-.. automodule:: qsonic.continuum_models.base_continuum_model
-   :members:
-   :undoc-members:
-
-
-.. automodule:: qsonic.continuum_models.picca_continuum_model
-   :members:
-   :undoc-members:
-   :show-inheritance:
-
-
-.. automodule:: qsonic.continuum_models.input_continuum_model
-   :members:
-   :undoc-members:
-   :show-inheritance:
-   :exclude-members: _find_append_continuum
-
-
-.. automodule:: qsonic.continuum_models.true_continuum_model
+.. automodule:: qsonic.continuum_models
    :members:
    :undoc-members:
    :show-inheritance:

--- a/docs/source/generated/continuum_models.rst
+++ b/docs/source/generated/continuum_models.rst
@@ -1,18 +1,10 @@
 qsonic.continuum_models
 =======================
 
-qsonic.continuum_models.base_continuum_model
-----------------------------------------------
-
-
 .. automodule:: qsonic.continuum_models.base_continuum_model
    :members:
    :undoc-members:
    :show-inheritance:
-
-
-qsonic.continuum_models.picca_continuum_model
-----------------------------------------------
 
 
 .. automodule:: qsonic.continuum_models.picca_continuum_model
@@ -21,8 +13,11 @@ qsonic.continuum_models.picca_continuum_model
    :show-inheritance:
 
 
-qsonic.continuum_models.true_continuum_model
-----------------------------------------------
+.. automodule:: qsonic.continuum_models.input_continuum_model
+   :members:
+   :undoc-members:
+   :show-inheritance:
+   :exclude-members: _find_append_continuum
 
 
 .. automodule:: qsonic.continuum_models.true_continuum_model

--- a/docs/source/generated/io.rst
+++ b/docs/source/generated/io.rst
@@ -1,4 +1,4 @@
-﻿qsonic.io
+﻿io
 ==================
 
 .. automodule:: qsonic.io

--- a/docs/source/generated/masks.rst
+++ b/docs/source/generated/masks.rst
@@ -1,4 +1,4 @@
-qsonic.masks
+masks
 =====================
 
 .. automodule:: qsonic.masks

--- a/docs/source/generated/mathtools.rst
+++ b/docs/source/generated/mathtools.rst
@@ -1,4 +1,4 @@
-qsonic.mathtools
+mathtools
 =========================
 
 .. automodule:: qsonic.mathtools

--- a/docs/source/generated/modules.rst
+++ b/docs/source/generated/modules.rst
@@ -9,6 +9,7 @@ Modules
 
    calibration
    catalog
+   continuum_models
    io
    masks
    mathtools

--- a/docs/source/generated/mpi_utils.rst
+++ b/docs/source/generated/mpi_utils.rst
@@ -1,4 +1,4 @@
-qsonic.mpi\_utils
+mpi\_utils
 ==========================
 
 .. automodule:: qsonic.mpi_utils

--- a/docs/source/generated/picca_continuum.rst
+++ b/docs/source/generated/picca_continuum.rst
@@ -1,4 +1,4 @@
-qsonic.picca\_continuum
+picca\_continuum
 ================================
 
 .. automodule:: qsonic.picca_continuum

--- a/docs/source/generated/scripts.qsonic_calib.rst
+++ b/docs/source/generated/scripts.qsonic_calib.rst
@@ -1,4 +1,4 @@
-qsonic.scripts.qsonic_calib
+qsonic_calib
 =========================================
 
 

--- a/docs/source/generated/scripts.qsonic_coadd_deltas.rst
+++ b/docs/source/generated/scripts.qsonic_coadd_deltas.rst
@@ -1,4 +1,4 @@
-qsonic.scripts.qsonic_coadd_deltas
+qsonic_coadd_deltas
 =======================================
 
 

--- a/docs/source/generated/scripts.qsonic_fit.rst
+++ b/docs/source/generated/scripts.qsonic_fit.rst
@@ -1,4 +1,4 @@
-qsonic.scripts.qsonic_fit
+qsonic_fit
 =======================================
 
 

--- a/docs/source/generated/spectrum.rst
+++ b/docs/source/generated/spectrum.rst
@@ -1,4 +1,4 @@
-qsonic.spectrum
+spectrum
 ========================
 
 .. automodule:: qsonic.spectrum

--- a/docs/source/howitworks.rst
+++ b/docs/source/howitworks.rst
@@ -82,7 +82,7 @@ This stage starts with the construction of a :class:`PiccaContinuumFitter <qsoni
 We then start iterating, which itself consists of three major steps: initialization, fitting, updating the global variables. The initialization sets ``cont_params`` variable of every Spectrum object. Continuum polynomial order is carried by setting ``cont_params[x]``. At each iteration:
 
 #. Global variables (mean continuum, var_lss) are saved to ``attributes.fits`` file (see :ref:`here <look into output files reference>`). This ensures the order of what is used in each iteration. 
-#. All spectra are fit (see :meth:`fit_continuum <qsonic.picca_continuum.PiccaContinuumFitter.fit_continuum>`).
+#. All spectra are fit (see :meth:`fit_continuum <qsonic.continuum_models.picca_continuum_model.PiccaContinuumModel.fit_continuum>`).
 #. Mean continuum is updated by stacking, smoothing and removing degenarate modes. We check for convergence (update is small). See :meth:`update_mean_cont <qsonic.picca_continuum.PiccaContinuumFitter.update_mean_cont>` and :meth:`_project_normalize_meancont <qsonic.picca_continuum.PiccaContinuumFitter._project_normalize_meancont>`.
 #. If we are fitting for var_lss, we fit and update by calculating variance statistics.
 

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -26,8 +26,9 @@ See :doc:`/generated/modules` for details.
 + `masks.py` provides maskers for sky, BAL and DLA. Can be imported without MPI. Sky mask is a simple text file, where colums are  *type* (unused), *wave_min* mininum wavelength, *wave_max* maximum wavelength, *frame* rest-frame (RF) or observed (OBS). BAL mask assumes related ``VMIN_CIV_450, VMAX_CIV_450, VMIN_CIV_2000, VMAX_CIV_2000`` values are already present in `catalog`. DLA masking takes both Lya and Lyb profiles into account, masks ``F<0.8`` and corrects for the wings.
 + `mathtools.py` hosts some functions and classes that are purely numerical. Can be imported without MPI.
 + `mpi_utils.py` hosts MPI related functions such as logging. Can be imported without MPI.
-+ `picca_continuum.py` fits each quasar continuum with a global mean as done in picca. Needs MPI.
++ `picca_continuum.py` fits each quasar continuum and calculates global statistics. Needs MPI.
 + `spectrum.py` has ``Spectrum`` class that stores each quasar spectrum. Can be imported without MPI.
++ `continuum_model` has the supported continuum models including fitting in the forest region as ``PiccaContinuumModel``, and input continuum from another method as ``InputContinuumModel``.
 
 .. toctree::
    :maxdepth: 2

--- a/py/qsonic/continuum_models/__init__.py
+++ b/py/qsonic/continuum_models/__init__.py
@@ -1,0 +1,9 @@
+from .base_continuum_model import BaseContinuumModel
+from .input_continuum_model import InputContinuumModel
+from .picca_continuum_model import PiccaContinuumModel
+from .true_continuum_model import TrueContinuumModel
+
+__all__ = [
+    "BaseContinuumModel", "PiccaContinuumModel", "InputContinuumModel",
+    "TrueContinuumModel"
+]

--- a/py/qsonic/continuum_models/base_continuum_model.py
+++ b/py/qsonic/continuum_models/base_continuum_model.py
@@ -1,0 +1,30 @@
+class BaseContinuumModel():
+    """The contract for BaseContinuumModel"""
+
+    def __init__(self):
+        raise NotImplementedError
+
+    def fit_continuum(self, spec):
+        """Fits the continuum for a single Spectrum. Should modify
+        :attr:`cont_params <qsonic.spectrum.Spectrum.cont_params>`
+        dictionary's ``valid`` and ``cont`` keys at least. ``x, xcov, chi2``
+        and ``dof`` keys should be set either here or in :meth:`init_spectra`.
+
+        Arguments
+        ---------
+        spec: Spectrum
+            Spectrum object to fit.
+        """
+        raise NotImplementedError
+
+    def init_spectra(self, spectra_list):
+        """ Initializes
+        :attr:`cont_params <qsonic.spectrum.Spectrum.cont_params>` for a list
+        of Spectrum objects. Specifically, set ``method`` key and any unused
+        keys in ``x, xcov, chi2, dof``.
+
+        Arguments
+        ---------
+        spectra_list: list(Spectrum)
+        """
+        raise NotImplementedError

--- a/py/qsonic/continuum_models/input_continuum_model.py
+++ b/py/qsonic/continuum_models/input_continuum_model.py
@@ -1,0 +1,219 @@
+import logging
+import warnings
+
+import fitsio
+import numpy as np
+
+from healpy import ang2pix
+
+from qsonic.mathtools import FastCubic1DInterp
+from qsonic.continuum_models.base_continuum_model import BaseContinuumModel
+
+
+def _find_append_continuum(
+        spec, wave_rf_1, dwave_rf, common_targetids, continua
+):
+    idx = np.nonzero(common_targetids == spec.targetid)[0]
+    if idx.size == 0:
+        return
+
+    idx = idx[0]
+    spec.cont_params['input_w1'] = wave_rf_1
+    spec.cont_params['input_dwave'] = dwave_rf
+    spec.cont_params['input_data'] = continua[idx]
+
+
+class InputContinuumModel(BaseContinuumModel):
+    """Input continuum model class.
+
+    Input continua should be in the rest frame with equal wavelength spacing.
+    These continua are then interpolated using a cubic spline. Uses fiducials
+    for mean flux and varlss interpolation.
+
+    The files are assumed to be organized by healpix **nside=8** with
+    **nested** ordering. For example, ``input-continuum-{nside}-{pixnum}.fits``
+    , where
+    ``pixnum = healpy.ang2pix(nside, ra_deg, dec_deg, lonlat=True, nest=True)``
+    . Each file should have at least two extensions: **FIBERMAP** and
+    **CONTINUA**.
+
+    - **FIBERMAP** extension should have the typical DESI fibermap columns:
+      ``TARGETID, Z, RA, DEC, PROGRAM, SURVEY``. Each ``TARGETID`` should occur
+      once.
+
+    - **CONTINUA** extention should be an ImageHDU and have the quasar continua
+      in the same order of ``TARGETID`` s in **FIBERMAP**. Its header should
+      declare the initial rest-frame wavelength by ``WAVE1`` key and the
+      rest-frame wavelength step by ``DWAVE`` key. The data should be in
+      ``(nqso, nwave)`` shape.
+
+    Parameters
+    ----------
+    input_dir: str
+        Input directory for all input-continuum FITS files.
+    meanflux_interp: FastLinear1DInterp
+        Interpolator for mean flux. If fiducial is not set, this equals to 1.
+    varlss_interp: FastLinear1DInterp or FastCubic1DInterp
+        Cubic spline for var_lss if fitting. Linear if from file.
+    eta_interp: FastCubic1DInterp
+        Interpolator for eta.
+    nside: int, default: 8
+        Healpy nside.
+    """
+
+    def __init__(
+            self, input_dir, meanflux_interp, varlss_interp, eta_interp,
+            nside=8
+    ):
+        self.input_dir = input_dir
+        self.meanflux_interp = meanflux_interp
+        self.varlss_interp = varlss_interp
+        self.eta_interp = eta_interp
+        self.nside = nside
+
+    def _read_continua_one_file(self, pixnum, targetids):
+        """Reads one input continuum file.
+
+        Arguments
+        ---------
+        pixnum: int
+            Healpix number
+        targetids: :external+numpy:py:class:`ndarray <numpy.ndarray>`
+            TARGETIDs in this healpix
+
+        Returns
+        -------
+        wave_rf_1: float
+            First wavelength in the rest frame.
+        dwave_rf: float
+            Rest-frame wavelength step
+        common_targetids: :external+numpy:py:class:`ndarray <numpy.ndarray>`
+            TARGETIDs that are found in the file.
+        continua: :external+numpy:py:class:`ndarray <numpy.ndarray>`
+            2D array of shape ``(common_targetids.size, nwave)``
+
+        Raises
+        ------
+        Exception
+            If the number of quasars in **FIBERMAP** and **CONTINUA** extension
+            do not match.
+        RuntimeWarning
+            If the file cannot be read. In this case, all objects are assumed
+            to have invalid continuum.
+        """
+        fname = \
+            f"{self.input_dir}/input-continuum-{self.nside}-{self.pixnum}.fits"
+
+        try:
+            with fitsio.FITS(fname) as fitsfile:
+                fbrmap = fitsfile['FIBERMAP'].read(columns='TARGETID')
+                hdr = fitsfile['CONTINUA'].read_header()
+                continua = fitsfile['CONTINUA'].read()
+        except Exception as e:
+            warnings.warn(
+                f"InputContinuumModel cannot read file {fname}. "
+                f"Reason {e}.")
+            return 0, 0, None, None
+
+        if fbrmap.size != continua.shape[0]:
+            raise Exception(
+                "InputContinuumModel file error. The number of quasars do not "
+                f"match between FIBERMAP and CONTINUA in {fname}.")
+
+        common_targetids, idx_fbr, _ = np.intersect1d(
+            fbrmap, targetids, return_indices=True)
+        hdr['WAVE1'], hdr['DWAVE'], common_targetids, continua[idx_fbr]
+
+    def _read_continua(self, spectra_list):
+        """Reads and sets input continuum for all elements in ``spectra_list``.
+        If a TARGETID is not found in its expected file, its continuum will be
+        set to invalid.
+
+        If found, :attr:`qsonic.spectrum.Spectrum.cont_params` dictionary gains
+        the following::
+
+            cont_params['input_w1'] (float): First rest-frame wavelength
+            cont_params['input_dwave'] (float): Rest-frame wavelength spacing
+            cont_params['input_data'] (ndarray): Input continuum
+
+        Arguments
+        ---------
+        spectra_list: list(Spectrum)
+            Spectrum objects.
+        """
+        local_catalog = np.hstack([_.catrow for _ in spectra_list]).copy()
+        local_catalog['HPXPIXEL'] = ang2pix(
+            self.nside, local_catalog['RA'], local_catalog['DEC'],
+            lonlat=True, nest=True)
+
+        # local_catalog is not sorted
+        idx_sort = local_catalog.argsort(order=['HPXPIXEL', 'TARGETID'])
+        spectra_list = np.array(spectra_list)[idx_sort]
+        local_catalog = local_catalog[idx_sort]
+        del idx_sort
+
+        unique_pix, s = np.unique(local_catalog['HPXPIXEL'], return_index=True)
+        hpx_split_catalog = np.split(local_catalog, s[1:])
+        hpx_split_spectra_list = np.split(spectra_list, s[1:])
+        del s, unique_pix
+
+        for cat, specs in zip(hpx_split_catalog, hpx_split_spectra_list):
+            pixnum = cat['HPXPIXEL'][0]
+            targetids = cat['TARGETID']
+            wave_rf_1, dwave_rf, common_targetids, continua = \
+                self._read_continua_one_file(pixnum, targetids)
+
+            if wave_rf_1 == 0:
+                continue
+
+            for spec in specs:
+                _find_append_continuum(
+                    spec, wave_rf_1, dwave_rf, common_targetids, continua)
+
+    def fit_continuum(self, spec):
+        """Input continuum reduction. Uses fiducials for mean flux and varlss
+        interpolation. Continuum is interpolated using a cubic spline.
+
+        Arguments
+        ---------
+        spec: Spectrum
+            Spectrum object to add true continuum.
+        """
+        if not spec.cont_params['valid']:
+            spec.cont_params['cont'] = None
+            spec.cont_params['chi2'] = -1
+            return
+
+        input_cont_interp = FastCubic1DInterp(
+            spec.cont_params['input_w1'], spec.cont_params['input_dwave'],
+            spec.cont_params['input_data'])
+
+        for arm, wave_arm in spec.forestwave.items():
+            cont_est = input_cont_interp(wave_arm / (1 + spec.z_qso))
+            cont_est *= self.meanflux_interp(wave_arm)
+            spec.cont_params['cont'][arm] = cont_est
+
+        spec.set_forest_weight(self.varlss_interp, self.eta_interp)
+        spec.calc_continuum_chi2()
+
+    def init_spectra(self, spectra_list):
+        """ Reads input continuum. Initializes
+        :attr:`cont_params <qsonic.spectrum.Spectrum.cont_params>` for a list
+        of Spectrum objects.
+
+        Arguments
+        ---------
+        spectra_list: list(Spectrum)
+            Spectrum objects.
+        """
+        logging.info("Initializing input continuum.")
+
+        for spec in spectra_list:
+            spec.cont_params['method'] = 'input'
+            spec.cont_params['valid'] = False
+            spec.cont_params['x'] = np.zeros(1)
+            spec.cont_params['xcov'] = np.eye(1)
+            spec.cont_params['dof'] = spec.get_real_size()
+            spec.cont_params['cont'] = {}
+
+        self._read_continua(spectra_list)

--- a/py/qsonic/continuum_models/picca_continuum_model.py
+++ b/py/qsonic/continuum_models/picca_continuum_model.py
@@ -1,0 +1,246 @@
+"""Picca continuum model."""
+import numpy as np
+from iminuit import Minuit
+from scipy.optimize import minimize
+
+from qsonic import QsonicException
+from qsonic.mathtools import mypoly1d
+from qsonic.continuum_models.base_continuum_model import BaseContinuumModel
+
+
+class PiccaContinuumModel(BaseContinuumModel):
+    """Picca continuum model class.
+
+    Parameters
+    ----------
+    meancont_interp: FastCubic1DInterp
+        Fast cubic spline object for the mean continuum.
+    meanflux_interp: FastLinear1DInterp
+        Interpolator for mean flux. If fiducial is not set, this equals to 1.
+    varlss_interp: FastLinear1DInterp or FastCubic1DInterp
+        Cubic spline for var_lss if fitting. Linear if from file.
+    eta_interp: FastCubic1DInterp
+        Interpolator for eta. Returns one if fiducial var_lss is set.
+    cont_order: int
+        Order of continuum polynomial from ``args.cont_order``.
+    rfwave0: float
+        First rest-frame wavelength center for the mean continuum.
+    denom: float
+        Denominator for the slope term in the continuum model.
+    minimizer: str
+        ``iminuit`` or ``l_bfgs_b`` to select the minimizer function.
+
+    Attributes
+    ----------
+    minimizer: function
+        Function that points to one of the minimizer options.
+    """
+
+    def __init__(
+            self, meancont_interp, meanflux_interp, varlss_interp,
+            eta_interp, cont_order, rfwave0, denom, minimizer
+    ):
+        self.meancont_interp = meancont_interp
+        self.meanflux_interp = meanflux_interp
+        self.varlss_interp = varlss_interp
+        self.eta_interp = eta_interp
+        self.cont_order = cont_order
+        self.rfwave0 = rfwave0
+        self.denom = denom
+
+        if minimizer == "iminuit":
+            self.minimizer = self._iminuit_minimizer
+        elif minimizer == "l_bfgs_b":
+            self.minimizer = self._scipy_l_bfgs_b_minimizer
+        else:
+            raise QsonicException(
+                "Undefined minimizer. Developer forgot to implement.")
+
+    def _continuum_costfn(self, x, wave, flux, ivar_sm, z_qso):
+        """Cost function to minimize for each quasar.
+
+        This is a modified chi2 where amplitude is also part of minimization.
+        Cost of each arm is simply added to the total cost.
+
+        Arguments
+        ---------
+        x: :external+numpy:py:class:`ndarray <numpy.ndarray>`
+            Polynomial coefficients for quasar diversity.
+        wave: dict(:external+numpy:py:class:`ndarray <numpy.ndarray>`)
+            Observed-frame wavelengths.
+        flux: dict(:external+numpy:py:class:`ndarray <numpy.ndarray>`)
+            Flux.
+        ivar_sm: dict(:external+numpy:py:class:`ndarray <numpy.ndarray>`)
+            Smooth inverse variance.
+        z_qso: float
+            Quasar redshift.
+
+        Returns
+        ---------
+        cost: float
+            Cost (modified chi2) for a given ``x``.
+        """
+        cost = 0
+
+        for arm, wave_arm in wave.items():
+            cont_est = self.get_continuum_model(x, wave_arm / (1 + z_qso))
+            # no_neg = np.sum(cont_est<0)
+            # penalty = wave_arm.size * no_neg**2
+
+            cont_est *= self.meanflux_interp(wave_arm)
+
+            var_lss = self.varlss_interp(wave_arm) * cont_est**2
+            eta = self.eta_interp(wave_arm)
+            weight = ivar_sm[arm] / (eta + ivar_sm[arm] * var_lss)
+            w = weight > 0
+
+            cost += np.dot(
+                weight, (flux[arm] - cont_est)**2
+            ) - np.log(weight[w]).sum()  # + penalty
+
+        return cost
+
+    def get_continuum_model(self, x, wave_rf_arm):
+        """Returns interpolated continuum model.
+
+        Arguments
+        ---------
+        x: :external+numpy:py:class:`ndarray <numpy.ndarray>`
+            Polynomial coefficients for quasar diversity.
+        wave_rf_arm: :external+numpy:py:class:`ndarray <numpy.ndarray>`
+            Rest-frame wavelength per arm.
+
+        Returns
+        ---------
+        cont: :external+numpy:py:class:`ndarray <numpy.ndarray>`
+            Continuum at `wave_rf_arm` values given `x`.
+        """
+        slope = np.log(wave_rf_arm / self.rfwave0) / self.denom
+
+        cont = self.meancont_interp(wave_rf_arm) * mypoly1d(x, 2 * slope - 1)
+        # Multiply with resolution
+        # Edges are difficult though
+
+        return cont
+
+    def _iminuit_minimizer(self, spec, a0):
+        def _cost(x):
+            return self._continuum_costfn(
+                x, spec.forestwave, spec.forestflux, spec.forestivar_sm,
+                spec.z_qso)
+
+        x0 = np.zeros_like(spec.cont_params['x'])
+        x0[0] = a0
+        mini = Minuit(_cost, x0)
+        mini.errordef = Minuit.LEAST_SQUARES
+        mini.migrad()
+
+        result = {}
+
+        result['valid'] = mini.valid
+        result['x'] = np.array(mini.values)
+        result['xcov'] = np.array(mini.covariance)
+
+        return result
+
+    def _scipy_l_bfgs_b_minimizer(self, spec, a0):
+        x0 = np.zeros_like(spec.cont_params['x'])
+        x0[0] = a0
+        mini = minimize(
+            self._continuum_costfn,
+            x0,
+            args=(spec.forestwave,
+                  spec.forestflux,
+                  spec.forestivar_sm,
+                  spec.z_qso),
+            method='L-BFGS-B',
+            bounds=None,
+            jac=None
+        )
+
+        result = {}
+
+        result['valid'] = mini.success
+        result['x'] = mini.x
+        result['xcov'] = mini.hess_inv.todense()
+
+        return result
+
+    def fit_continuum(self, spec):
+        """Fits the continuum for a single Spectrum.
+
+        This function uses
+        :attr:`forestivar_sm <qsonic.spectrum.Spectrum.forestivar_sm>` in
+        inverse variance, which must be smoothed beforehand.
+        It also modifies
+        :attr:`cont_params <qsonic.spectrum.Spectrum.cont_params>`
+        dictionary's ``valid, cont, x, xcov, chi2, dof`` keys.
+        If the best-fitting continuum is **negative at any point**, the fit is
+        **invalidated**. Chi2 is set separately without using the
+        :meth:`cost function <._continuum_costfn>`.
+        ``x`` key is the best-fitting parameter, and ``xcov`` is their inverse
+        Hessian ``hess_inv`` given by
+        :external+scipy:func:`scipy.optimize.minimize` using 'L-BFGS-B' method.
+
+        Arguments
+        ---------
+        spec: Spectrum
+            Spectrum object to fit.
+        """
+        # We can precalculate meanflux and varlss here,
+        # and store them in respective keys to spec.cont_params
+
+        def get_a0():
+            a0 = 0
+            n0 = 1e-6
+            for arm, ivar_arm in spec.forestivar_sm.items():
+                a0 += np.dot(spec.forestflux[arm], ivar_arm)
+                n0 += np.sum(ivar_arm)
+
+            return a0 / n0
+
+        result = self.minimizer(spec, get_a0())
+        spec.cont_params['valid'] = result['valid']
+
+        if spec.cont_params['valid']:
+            spec.cont_params['cont'] = {}
+            for arm, wave_arm in spec.forestwave.items():
+                cont_est = self.get_continuum_model(
+                    result['x'], wave_arm / (1 + spec.z_qso))
+
+                if any(cont_est < 0):
+                    spec.cont_params['valid'] = False
+                    break
+
+                cont_est *= self.meanflux_interp(wave_arm)
+                # cont_est *= self.flux_stacker(wave_arm)
+                spec.cont_params['cont'][arm] = cont_est
+
+        spec.set_forest_weight(self.varlss_interp, self.eta_interp)
+        # We can further eliminate spectra based chi2
+        spec.calc_continuum_chi2()
+
+        if spec.cont_params['valid']:
+            spec.cont_params['x'] = result['x']
+            spec.cont_params['xcov'] = result['xcov']
+        else:
+            spec.cont_params['cont'] = None
+            spec.cont_params['chi2'] = -1
+
+    def init_spectra(self, spectra_list):
+        """ Initializes
+        :attr:`cont_params <qsonic.spectrum.Spectrum.cont_params>` for a list
+        of Spectrum objects.
+
+        Arguments
+        ---------
+        spectra_list: list(Spectrum)
+            Spectrum objects to fit.
+        """
+        for spec in spectra_list:
+            spec.cont_params['method'] = 'picca'
+            spec.cont_params['x'] = np.append(
+                spec.cont_params['x'][0], np.zeros(self.cont_order))
+            spec.cont_params['xcov'] = np.eye(self.cont_order + 1)
+            spec.cont_params['dof'] = \
+                spec.get_real_size() - self.cont_order - 1

--- a/py/qsonic/continuum_models/picca_continuum_model.py
+++ b/py/qsonic/continuum_models/picca_continuum_model.py
@@ -1,4 +1,3 @@
-"""Picca continuum model."""
 import logging
 import numpy as np
 from iminuit import Minuit

--- a/py/qsonic/continuum_models/picca_continuum_model.py
+++ b/py/qsonic/continuum_models/picca_continuum_model.py
@@ -1,4 +1,5 @@
 """Picca continuum model."""
+import logging
 import numpy as np
 from iminuit import Minuit
 from scipy.optimize import minimize
@@ -237,6 +238,8 @@ class PiccaContinuumModel(BaseContinuumModel):
         spectra_list: list(Spectrum)
             Spectrum objects to fit.
         """
+        logging.info("Initializing Picca continuum fitting.")
+
         for spec in spectra_list:
             spec.cont_params['method'] = 'picca'
             spec.cont_params['x'] = np.append(

--- a/py/qsonic/continuum_models/true_continuum_model.py
+++ b/py/qsonic/continuum_models/true_continuum_model.py
@@ -1,4 +1,3 @@
-"""True continuum for mock analysis."""
 import logging
 import numpy as np
 
@@ -7,8 +6,9 @@ from qsonic.continuum_models.base_continuum_model import BaseContinuumModel
 
 
 class TrueContinuumModel(BaseContinuumModel):
-    """True continuum reduction. Uses fiducials for mean flux and varlss
-    interpolation. Continuum is interpolated using a cubic spline.
+    """True continuum model class for mock analysis. Uses fiducials for mean
+    flux and varlss interpolation. Continuum is interpolated using a cubic
+    spline.
 
     Parameters
     ----------

--- a/py/qsonic/continuum_models/true_continuum_model.py
+++ b/py/qsonic/continuum_models/true_continuum_model.py
@@ -1,0 +1,66 @@
+"""True continuum for mock analysis."""
+import logging
+import numpy as np
+
+from qsonic.mathtools import FastCubic1DInterp
+from qsonic.continuum_models.base_continuum_model import BaseContinuumModel
+
+
+class TrueContinuumModel(BaseContinuumModel):
+    """True continuum reduction. Uses fiducials for mean flux and varlss
+    interpolation. Continuum is interpolated using a cubic spline.
+
+    Parameters
+    ----------
+    meanflux_interp: FastLinear1DInterp
+        Interpolator for mean flux. If fiducial is not set, this equals to 1.
+    varlss_interp: FastLinear1DInterp or FastCubic1DInterp
+        Cubic spline for var_lss if fitting. Linear if from file.
+    """
+
+    def __init__(self, meanflux_interp, varlss_interp):
+        self.meanflux_interp = meanflux_interp
+        self.varlss_interp = varlss_interp
+
+    def fit_continuum(self, spec):
+        """True continuum reduction. Uses fiducials for mean flux and varlss
+        interpolation. Continuum is interpolated using a cubic spline.
+
+        Arguments
+        ---------
+        spec: Spectrum
+            Spectrum object to add true continuum.
+        """
+        w1 = spec.cont_params['true_data_w1']
+        dwave = spec.cont_params['true_data_dwave']
+        tcont = spec.cont_params['true_data']
+
+        tcont_interp = FastCubic1DInterp(w1, dwave, tcont)
+
+        for arm, wave_arm in spec.forestwave.items():
+            cont_est = tcont_interp(wave_arm)
+            cont_est *= self.meanflux_interp(wave_arm)
+            spec.cont_params['cont'][arm] = cont_est
+
+        spec.set_forest_weight(self.varlss_interp)
+        spec.calc_continuum_chi2()
+
+    def init_spectra(self, spectra_list):
+        """ Initializes
+        :attr:`cont_params <qsonic.spectrum.Spectrum.cont_params>` for a list
+        of Spectrum objects.
+
+        Arguments
+        ---------
+        spectra_list: list(Spectrum)
+            Spectrum objects.
+        """
+        logging.info("Initializing true continuum.")
+
+        for spec in spectra_list:
+            spec.cont_params['method'] = 'true'
+            spec.cont_params['valid'] = True
+            spec.cont_params['x'] = np.zeros(1)
+            spec.cont_params['xcov'] = np.eye(1)
+            spec.cont_params['dof'] = spec.get_real_size()
+            spec.cont_params['cont'] = {}

--- a/py/qsonic/scripts/qsonic_fit.py
+++ b/py/qsonic/scripts/qsonic_fit.py
@@ -62,7 +62,7 @@ def args_logic_fnc_qsonic_fit(args):
 
     is_true_continuum = args.continuum_model == "true" or args.true_continuum
     args.true_continuum = is_true_continuum
-    args.continuum_model = "true"
+
     condition_msg = [
         (args.true_continuum and not args.mock_analysis,
             "True continuum is only applicable to mock analysis."),
@@ -70,6 +70,8 @@ def args_logic_fnc_qsonic_fit(args):
             "True continuum analysis requires fiducial mean flux."),
         (args.true_continuum and not args.fiducial_varlss,
             "True continuum analysis requires fiducial var_lss."),
+        (args.true_continuum and args.input_continuum_dir,
+            "Both true continuum and input continuum cannot be set.")
         (args.wave2 <= args.wave1,
             "wave2 must be greater than wave1."),
         (args.forest_w2 <= args.forest_w1,
@@ -83,6 +85,11 @@ def args_logic_fnc_qsonic_fit(args):
     for c, msg in condition_msg:
         if c:
             logging.error(msg)
+
+    if is_true_continuum:
+        args.continuum_model = "true"
+    if args.input_continuum_dir:
+        args.continuum_model = "input"
 
     return not any(_[0] for _ in condition_msg)
 

--- a/py/qsonic/scripts/qsonic_fit.py
+++ b/py/qsonic/scripts/qsonic_fit.py
@@ -60,6 +60,9 @@ def get_parser(add_help=True):
 def args_logic_fnc_qsonic_fit(args):
     args.arms = list(set(args.arms))
 
+    is_true_continuum = args.continuum_model == "true" or args.true_continuum
+    args.true_continuum = is_true_continuum
+    args.continuum_model = "true"
     condition_msg = [
         (args.true_continuum and not args.mock_analysis,
             "True continuum is only applicable to mock analysis."),
@@ -260,16 +263,12 @@ def mpi_continuum_fitting(spectra_list, args, comm, mpi_rank):
     start_time = time.time()
     qcfit = PiccaContinuumFitter(args)
 
-    if not args.true_continuum:
-        # Fit continua
-        # Stack all spectra in each process
-        # Broadcast and recalculate global functions
-        # Iterate
-        logging.info("Fitting continuum.")
-        qcfit.iterate(spectra_list)
-    else:
-        logging.info("True continuum.")
-        qcfit.true_continuum(spectra_list, args)
+    # Fit continua
+    # Stack all spectra in each process
+    # Broadcast and recalculate global functions
+    # Iterate
+    logging.info("Fitting continuum.")
+    qcfit.iterate(spectra_list)
 
     valid_spectra = list(qsonic.spectrum.valid_spectra(spectra_list))
 

--- a/py/qsonic/scripts/qsonic_fit.py
+++ b/py/qsonic/scripts/qsonic_fit.py
@@ -71,7 +71,7 @@ def args_logic_fnc_qsonic_fit(args):
         (args.true_continuum and not args.fiducial_varlss,
             "True continuum analysis requires fiducial var_lss."),
         (args.true_continuum and args.input_continuum_dir,
-            "Both true continuum and input continuum cannot be set.")
+            "Both true continuum and input continuum cannot be set."),
         (args.wave2 <= args.wave1,
             "wave2 must be greater than wave1."),
         (args.forest_w2 <= args.forest_w1,

--- a/tests/test_mpi_utils.py
+++ b/tests/test_mpi_utils.py
@@ -38,17 +38,18 @@ class TestMPIUtils(TestCase):
         parser = get_parser()
 
         options = ("--input-dir indir --catalog incat -o outdir "
-                   "--mock-analysis --true-continuum "
+                   "--mock-analysis --continuum-model true "
                    "--fiducial-meanflux mflux "
                    "--fiducial-varlss varlss").split(' ')
         args = qsonic.mpi_utils.mpi_parse(parser, comm, mpi_rank, options,
                                           args_logic_fnc_qsonic_fit)
+        assert args.continuum_model == "true"
         assert args.true_continuum
         assert args.mock_analysis
 
         with pytest.raises(SystemExit):
             options = ("--input-dir indir --catalog incat -o outdir "
-                       "--true-continuum").split(' ')
+                       "--continuum-model true").split(' ')
             qsonic.mpi_utils.mpi_parse(parser, comm, mpi_rank, options,
                                        args_logic_fnc_qsonic_fit)
 

--- a/tests/test_qsonic_fit.py
+++ b/tests/test_qsonic_fit.py
@@ -10,7 +10,7 @@ class TestQsonicFit(TestCase):
 
         options = (
             "--input-dir indir --catalog incat -o outdir "
-            "--true-continuum --mock-analysis --fiducial-meanflux mf "
+            "--continuum-model true --mock-analysis --fiducial-meanflux mf "
             "--fiducial-varlss vs"
         ).split(' ')
         args = parser.parse_args(options)


### PR DESCRIPTION
This PR restructures the continuum model and moves it to separate modules. Input continua can be provided in the quasar rest frame. Doc tree does not have module paths.